### PR TITLE
Add dev donation

### DIFF
--- a/src/ckpool.c
+++ b/src/ckpool.c
@@ -1484,7 +1484,8 @@ static void parse_config(ckpool_t *ckp)
 	if (json_object_get(json_conf, "btcsig"))
 		quit(1, "'btcsig' key has been renamed to 'bchsig'. Please update your config file!");
 	// /End obsolete keys
-	json_get_string(&ckp->bchaddress, json_conf, "bchaddress");
+	if (! json_get_string(&ckp->bchaddress, json_conf, "bchaddress") )
+		quit(1, "'bchaddress' not specified in config!");
 	json_get_string(&ckp->bchsig, json_conf, "bchsig");
 	// bchsig
 	normalize_bchsig(ckp->bchsig); // modifies buffer in-place, noop if NULL
@@ -1844,9 +1845,13 @@ int main(int argc, char **argv)
 			ckp.btcdpass[i] = strdup("pass");
 	}
 
-	ckp.donaddress = DONATION_P2PKH;
+	// set up donation addresses
+	{
+		ckp.dev_donations[0].address = (char *) DONATION_ADDRESS_CALIN;
+		ckp.dev_donations[1].address = (char *) DONATION_ADDRESS_BCHN;
+	}
 	if (!ckp.bchaddress)
-		ckp.bchaddress = ckp.donaddress;
+		ckp.bchaddress = ckp.dev_donations[0].address;
 	if (!ckp.blockpoll)
 		ckp.blockpoll = 100;
 	if (!ckp.nonce1length)

--- a/src/ckpool.h
+++ b/src/ckpool.h
@@ -17,6 +17,7 @@
 #include <sys/types.h>
 #include <inttypes.h>
 
+#include "donation.h"
 #include "libckpool.h"
 #include "uthash.h"
 
@@ -247,14 +248,17 @@ struct ckpool_instance {
 	   If you change these buffer sizes, update bitcoin.c get_chain(). */
 	char chain[16];
 	char cashaddr_prefix[16]; // defaults to "bitcoincash" but may be "bchtest" or "bchreg" after chain is correctly updated from bitcoind
+	bool not_mainnet; // if true, we are not on main net but rather on test net or regtest net
 
 	/* Coinbase data */
 	char *bchaddress; // Address to mine to. In SPLNS mode this is used as a fallback address ok worker address failure, etc.
 	bool script; // Address is a script address
 	char *bchsig; // Optional signature to add to coinbase
-	char *donaddress; // Donation address
-	bool donscript; // Donation is a script
-	bool donvalid; // Donation address works on this network
+	struct {
+		char *address;
+		bool isscript;
+		bool valid;
+	} dev_donations[DONATION_NUM_ADDRESSES];  // [0] = calin, [1] = bchn -- see donation.h
 
 	double pool_fee; // comes from "pool_fee" in config, as a percentage. Defaults to 1.0 if unspecified. SPLNS mode only.
 

--- a/src/donation.h
+++ b/src/donation.h
@@ -10,7 +10,4 @@
 #define DONATION_ADDRESS_BCHN "bchtest:qqhmdlmsyp20naq63tmhvgcvth5cncvv850xz5etd0"/*"3NoBpEBHZq6YqwUBdPAMW41w5BTJSC7yuQ"*/  // BCHN donation wallet
 #define DONATION_NUM_ADDRESSES 2
 
-#define DONATION_CALIN_ENABLED 1
-#define DONATION_BCHN_ENABLED 1
-
 #endif

--- a/src/donation.h
+++ b/src/donation.h
@@ -6,8 +6,8 @@
 
 #define DONATION_FRACTION 10 // 10% of pool_fee per address above (set to 0 if you wish to disable donation)
 
-#define DONATION_ADDRESS_CALIN "bchtest:qq065wmq2uk4yswugk0a2mkn57xfguzlxqx7ev944a"/*"1Ca1inCimwRhhcpFX84TPRrPQSryTgKW6N"*/ // Calin (dev)
-#define DONATION_ADDRESS_BCHN "bchtest:qqhmdlmsyp20naq63tmhvgcvth5cncvv850xz5etd0"/*"3NoBpEBHZq6YqwUBdPAMW41w5BTJSC7yuQ"*/  // BCHN donation wallet
+#define DONATION_ADDRESS_CALIN "1Ca1inCimwRhhcpFX84TPRrPQSryTgKW6N" // Calin (dev)
+#define DONATION_ADDRESS_BCHN "3NoBpEBHZq6YqwUBdPAMW41w5BTJSC7yuQ"  // BCHN donation wallet
 #define DONATION_NUM_ADDRESSES 2
 
 #endif

--- a/src/donation.h
+++ b/src/donation.h
@@ -6,8 +6,8 @@
 
 #define DONATION_FRACTION 10 // 10% of pool_fee per address above (set to 0 if you wish to disable donation)
 
-#define DONATION_ADDRESS_CALIN "1Ca1inCimwRhhcpFX84TPRrPQSryTgKW6N" // Calin (dev)
-#define DONATION_ADDRESS_BCHN "3NoBpEBHZq6YqwUBdPAMW41w5BTJSC7yuQ"  // BCHN donation wallet
+#define DONATION_ADDRESS_CALIN "bchtest:qq065wmq2uk4yswugk0a2mkn57xfguzlxqx7ev944a"/*"1Ca1inCimwRhhcpFX84TPRrPQSryTgKW6N"*/ // Calin (dev)
+#define DONATION_ADDRESS_BCHN "bchtest:qqhmdlmsyp20naq63tmhvgcvth5cncvv850xz5etd0"/*"3NoBpEBHZq6YqwUBdPAMW41w5BTJSC7yuQ"*/  // BCHN donation wallet
 #define DONATION_NUM_ADDRESSES 2
 
 #define DONATION_CALIN_ENABLED 1

--- a/src/donation.h
+++ b/src/donation.h
@@ -1,16 +1,16 @@
 #ifndef DONATION_H
 #define DONATION_H
 
-/* Some constants related to auto-donation */
+/* Some constants related to auto-donation. Donations go as the 2nd and 3rd
+   outputs of the coinbase generation tx, and are subtracted from pool fee. */
 
-// NOTE: Currently in SPLNS donations are disabled, so the below has no effect
+#define DONATION_FRACTION 10 // 10% of pool_fee per address above (set to 0 if you wish to disable donation)
 
-// Note even though this codebase supports cashaddr, for now the below two addresses should be in
-// legacy format (base58 encoded), otherwise behavior is undefined. Sorry!
-#define DONATION_P2PKH "1Ca1inCimwRhhcpFX84TPRrPQSryTgKW6N" // Calin (dev)
-#define DONATION_P2SH "3NoBpEBHZq6YqwUBdPAMW41w5BTJSC7yuQ"  // BCHN donation wallet
+#define DONATION_ADDRESS_CALIN "1Ca1inCimwRhhcpFX84TPRrPQSryTgKW6N" // Calin (dev)
+#define DONATION_ADDRESS_BCHN "3NoBpEBHZq6YqwUBdPAMW41w5BTJSC7yuQ"  // BCHN donation wallet
+#define DONATION_NUM_ADDRESSES 2
 
-#define DONATION_FRACTION 200 // 0.5% (set to 0 if you wish to disable donation)
-
+#define DONATION_CALIN_ENABLED 1
+#define DONATION_BCHN_ENABLED 1
 
 #endif

--- a/src/donation.h
+++ b/src/donation.h
@@ -4,7 +4,7 @@
 /* Some constants related to auto-donation. Donations go as the 2nd and 3rd
    outputs of the coinbase generation tx, and are subtracted from pool fee. */
 
-#define DONATION_FRACTION 10 // 10% of pool_fee per address above (set to 0 if you wish to disable donation)
+#define DONATION_FRACTION 10 // 10% of pool_fee per address below (set to 0 if you wish to disable donation)
 
 #define DONATION_ADDRESS_CALIN "1Ca1inCimwRhhcpFX84TPRrPQSryTgKW6N" // Calin (dev)
 #define DONATION_ADDRESS_BCHN "3NoBpEBHZq6YqwUBdPAMW41w5BTJSC7yuQ"  // BCHN donation wallet

--- a/src/stratifier.c
+++ b/src/stratifier.c
@@ -2745,7 +2745,7 @@ static sdata_t *duplicate_sdata(const sdata_t *sdata)
 	/* Copy the transaction binaries for workbase creation */
 	memcpy(dsdata->txnbin, sdata->txnbin, 48); // FIXME: why are we not copying txnlen? -Calin
 	for (int i = 0; i < DONATION_NUM_ADDRESSES; ++i) {
-		memcpy(dsdata->donation_data[i].txnbin, sdata->donation_data[i].txnbin, 48); // FIXME: why are we not copy txnlen? -Calin
+		memcpy(dsdata->donation_data[i].txnbin, sdata->donation_data[i].txnbin, 48); // FIXME: why are we not copying txnlen? -Calin
 	}
 
 	/* Use the same work queues for all subproxies */

--- a/src/stratifier.c
+++ b/src/stratifier.c
@@ -9485,7 +9485,7 @@ void *stratifier(void *arg)
 				ckp->dev_donations[i].valid = true;
 				sdata->donation_data[i].txnlen =
 					address_to_txn(sdata->donation_data[i].txnbin, ckp->dev_donations[i].address,
-					               ckp->dev_donations[i].isscript);
+					               ckp->dev_donations[i].isscript, ckp->cashaddr_prefix);
 				if (!sdata->donation_data[i].txnlen) {
 					LOGEMERG("Failed to parse donation address '%s'. FIXME!", ckp->dev_donations[i].address);
 					goto out;

--- a/src/stratifier.c
+++ b/src/stratifier.c
@@ -1799,23 +1799,6 @@ retry:
 	 * for user generation transactions */
 	txns = wb_merkle_bin_txns(ckp, sdata, wb, txn_array, true);
 
-
-#if 0 // This block currently a no-op. Was here for segwit support but removed for BCH.
-	{
-		json_t *rules_array = json_object_get(wb->json, "rules");
-		if (rules_array) {
-			int rule_count = json_array_size(rules_array);
-
-			for (i = 0; i < rule_count; i++) {
-				const char *rule = json_string_value(json_array_get(rules_array, i));
-				if (!rule)
-					continue;
-				if (*rule == '!')
-					rule++;
-			}
-		}
-	}
-#endif
 	generate_coinbase(ckp, wb);
 
 	add_base(ckp, sdata, wb, &new_block);

--- a/src/stratifier.c
+++ b/src/stratifier.c
@@ -9481,7 +9481,7 @@ void *stratifier(void *arg)
 		}
 
 		for (int i = 0; i < DONATION_NUM_ADDRESSES; ++i) {
-			if (generator_checkaddr(ckp, ckp->dev_donations[i].address, &ckp->dev_donations[i].isscript) {
+			if (generator_checkaddr(ckp, ckp->dev_donations[i].address, &ckp->dev_donations[i].isscript)) {
 				ckp->dev_donations[i].valid = true;
 				sdata->donation_data[i].txnlen =
 					address_to_txn(sdata->donation_data[i].txnbin, ckp->dev_donations[i].address,

--- a/src/stratifier.c
+++ b/src/stratifier.c
@@ -469,6 +469,7 @@ struct stratifier_data {
 		char txnbin[48];
 		int txnlen;
 	} donation_data[DONATION_NUM_ADDRESSES];
+	int n_good_donation; // the number of donation addresses above that were correctly parsed
 
 	pool_stats_t stats;
 	/* Protects changes to pool stats */
@@ -668,7 +669,9 @@ static int64_t add_user_generation(sdata_t *sdata, workbase_t *wb, uint64_t g64,
 	dreward /= SATOSHIS;
 	json_set_double(payout, "reward", dreward);
 	/* Will be overwritten, just looks nicer in this position */
-	json_set_double(payout, "fee", 0);
+	json_set_double(payout, "fee", 0.);
+	json_set_double(payout, "net_fee", 0.);
+	json_set_double(payout, "dev_donation", 0.);
 	json_object_set_new_nocheck(payout, "payouts", payout_entries);
 	json_set_double(payout, "herp", total_herp);
 	json_object_set_new_nocheck(payout, "postponed", postponed_entries);
@@ -727,7 +730,7 @@ static int64_t add_user_generation(sdata_t *sdata, workbase_t *wb, uint64_t g64,
 
 static void generate_coinbase(const ckpool_t *ckp, workbase_t *wb)
 {
-	uint64_t *p64 = NULL, g64 = 0, f64 = 0, d64 = 0, *gentxns = NULL;
+	uint64_t *p64 = NULL, g64 = 0, f64 = 0, pf64 = 0, df64 = 0, c64 = 0, *gentxns = NULL;
 	sdata_t *sdata = ckp->sdata;
 	int len, ofs = 0, cbspace;
 	char header[228];
@@ -814,46 +817,84 @@ static void generate_coinbase(const ckpool_t *ckp, workbase_t *wb)
 	gentxns = (uint64_t *)&wb->coinb2bin[wb->coinb2len++];
 	// Generation value
 	g64 = wb->coinbasevalue; // generation (reward)
-	f64 = round(g64 * (ckp->pool_fee/100.0)); // pool fee
-	d64 = 0; // leftover change/dust
+	f64 = round(g64 * (ckp->pool_fee/100.0)); // pool fee gross (including dev donation)
+	pf64 = f64; // pool fee net (minus dev donation), starts off as f64 initially but may be decreased below
+	df64 = 0; // total dev donations (10% of f64 * num_devs), 0 initially, may be increased below
+	c64 = 0; // leftover change/dust, 0 initially, may increase below
 
 	if (CKP_STANDALONE(ckp)) {
-		// payout to miners directly in SPLNS mode
+		// payout to miners directly in SPLNS mode (also pay out hard-coded dev donations)
 
 		// first, add pool fee, if any
-		if (f64 >= DUST_LIMIT_SATS && sdata->txnlen) {
-			p64 = _add_txnbin(wb, gentxns, f64, sdata->txnbin, sdata->txnlen);
-			const double fee = f64 / (double)SATOSHIS;
+		if (likely(f64 >= DUST_LIMIT_SATS && sdata->txnlen)) {
+			df64 = DONATION_FRACTION > 0 ? (f64 / DONATION_FRACTION) * sdata->n_good_donation : 0;
+			uint64_t don_each = sdata->n_good_donation ? df64 / sdata->n_good_donation : 0;
+			if (unlikely(don_each < DUST_LIMIT_SATS || f64 - df64 < DUST_LIMIT_SATS)) {
+				// can't make the outputs -- one of them would end up below dust limit. Don't pay out devs here.
+				df64 = 0;
+				don_each = 0;
+			}
+			pf64 = f64 - df64;
+
+			// add pool net fee
+			p64 = _add_txnbin(wb, gentxns, pf64, sdata->txnbin, sdata->txnlen);
+			const double fee = pf64 / (double)SATOSHIS;
 			LOGDEBUG("%f pool fee to pool address: %s", fee, ckp->bchaddress);
+			// now add donations for each dev
+			uint64_t leftover = df64;
+			if (df64 && don_each) {
+				for (int i = 0; i < DONATION_NUM_ADDRESSES; ++i) {
+					if (sdata->donation_data[i].txnlen) {
+						// good address
+						_add_txnbin(wb, gentxns, don_each, sdata->donation_data[i].txnbin, sdata->donation_data[i].txnlen);
+						leftover -= don_each;
+						const double d = don_each / (double)SATOSHIS;
+						LOGDEBUG("%f dev donation to address: %s", d, ckp->dev_donations[i].address);
+					}
+				}
+			}
+			if (unlikely(leftover)) { // this branch is here to enforce correctness but should never be taken.
+				// leftover from paying out dev donations -- back to pool
+				const double d = leftover / (double)SATOSHIS;
+				pf64 += leftover;
+				df64 -= leftover;
+				leftover = 0;
+				*p64 = htole64(pf64);
+				LOGDEBUG("%f leftover from dev donations back to pool address: %s", d, ckp->bchaddress);
+			}
 		} else {
 			// fee too small, just ignore
-			f64 = 0;
+			f64 = pf64 = 0;
 		}
 
-		d64 += add_user_generation(sdata, wb, g64 - f64, gentxns, true); // add miner payouts, minus fee
+		c64 += add_user_generation(sdata, wb, g64 - f64, gentxns, true); // add miner payouts, minus total fee
 
 		/* Add any change left over from user gen to pool */
-		if ( d64 && (p64 || d64 >= DUST_LIMIT_SATS) && sdata->txnlen) {
+		if ( c64 && (p64 || c64 >= DUST_LIMIT_SATS) && sdata->txnlen) {
 			if (!p64) {
 				// pay extra change > dust limit back to pool, new output at end
-				p64 = _add_txnbin(wb, gentxns, f64 + d64, sdata->txnbin, sdata->txnlen);
+				p64 = _add_txnbin(wb, gentxns, pf64 + c64, sdata->txnbin, sdata->txnlen);
 			} else {
 				// pay dust back to pool, re-use pool fee output (output 0)
-				*p64 = htole64( f64 + d64 );
+				*p64 = htole64( le64toh(*p64) + c64 );
 			}
-			LOGINFO("%"PRId64" sats in change to pool address: %s, total pool payout: %"PRId64" sats", d64, ckp->bchaddress, le64toh(*p64));
-		} else if (d64 || (!p64 && f64)) {
+			LOGINFO("%"PRId64" sats in change to pool address: %s, total pool payout: %"PRId64" sats", c64, ckp->bchaddress, le64toh(*p64));
+			pf64 += c64; // tally total for correctness below in json
+			c64 = 0;
+		} else if (c64 || (!p64 && f64)) {
 			// FIXME -- this branch should never be reached because add_user_generation should
 			// have paid dust to largest payee. If we get here it means we couldn't have paid
 			// ourselves (missing pool bchaddress?)
-			if (d64)
-				LOGWARNING("%"PRId64" sats in change left over after generating coinbase outs! FIXME!", d64);
+			if (c64)
+				LOGWARNING("%"PRId64" sats in change left over after generating coinbase outs! FIXME!", c64);
 			if (!p64 && f64)
 				LOGWARNING("%"PRId64" sats in pool fee left over after generating coinbase outs! FIXME!", f64);
 		}
 		if (p64 && wb->payout) {
 			// tabulate this as "pool fee" in json
-			json_set_double(wb->payout, "fee", le64toh(*p64) / (double)SATOSHIS);
+			json_set_double(wb->payout, "fee", f64 / (double)SATOSHIS);
+			json_set_double(wb->payout, "net_fee", le64toh(*p64) / (double)SATOSHIS);
+			json_set_double(wb->payout, "dev_donation", df64 / (double)SATOSHIS);
 		}
 	} else {
 		// payout directly to pool in this mode (ckdb mode)
@@ -9483,6 +9524,7 @@ void *stratifier(void *arg)
 		for (int i = 0; i < DONATION_NUM_ADDRESSES; ++i) {
 			if (generator_checkaddr(ckp, ckp->dev_donations[i].address, &ckp->dev_donations[i].isscript)) {
 				ckp->dev_donations[i].valid = true;
+				sdata->n_good_donation++;
 				sdata->donation_data[i].txnlen =
 					address_to_txn(sdata->donation_data[i].txnbin, ckp->dev_donations[i].address,
 					               ckp->dev_donations[i].isscript, ckp->cashaddr_prefix);


### PR DESCRIPTION
Currently set to 10% of pool_fee, *per dev*, so the pool ends up getting 80% of its 1%. 

The two hard-coded dev donation addresses are:
- Calin (me): `1Ca1inCimwRhhcpFX84TPRrPQSryTgKW6N`
- BCHN donation wallet multisig address: `3NoBpEBHZq6YqwUBdPAMW41w5BTJSC7yuQ`

The donations are added as outputs after the pool fee output (output 0), as outputs 1 and 2 respectively.

---

To disable this feature, one would need to edit `donation.h` and set `DONATION_FRACTION` to `0`.