### PR TITLE
WIP: Add "mindiff_overrides" key to config to allow per-client, useragent based raised minimum difficulty

### DIFF
--- a/README
+++ b/README
@@ -337,6 +337,20 @@ miners to in redirector mode. They must be valid resolvable URLs+ports.
 "maxdiff" : Optional maximum diff that vardiff will clamp to where zero is no
 maximum.
 
+"mindiff_overrides" : Optional JSON object (dictionary) of useragent, mindiff
+pairs, e.g: `"mindiff_overrides" : { "nicehash" : 500000, "foohash" : 750000 }`
+This is a mechanism to support a raised minimum difficulty for clients
+connecting to the pool based on their "useragent" string (that they normally
+send via `mining.subscribe` on initial connect).  The "useragent" specified
+here is a prefix match (case insensitive).  If a client's useragent matches the
+specified prefix, then it will have its minimum and starting difficulty set to
+the override value.  Note: The override values specified here cannot be lower
+than the pool's "mindiff" setting -- they must always be higher (similarly this
+value must also be below "maxdiff").  This mechanism was initially designed so
+that NiceHash clients can connect to a pool and get a special-cased raised
+difficulty  (since NiceHash refuses to operate if share difficulty is < 500000
+as of the time of this writing).
+
 "logdir" : Which directory to store pool and client logs. Default "logs"
 
 "maxclients" : Optional upper limit on the number of clients ckpool will

--- a/src/ckpool.c
+++ b/src/ckpool.c
@@ -1495,7 +1495,7 @@ static void parse_mindiff_overrides(ckpool_t *ckp, json_t *obj, const size_t n_k
 			         ckp->mindiff_overrides[i].useragent,
 			         ckp->mindiff_overrides[i].mindiff);
 		}
-		LOGDEBUG("mindiff_overrides: %d overrides will be applied to clients on mining.subscribe", (int)ckp->n_mindiff_overrides);
+		LOGDEBUG("mindiff_overrides: %d override(s) parsed ok", (int)ckp->n_mindiff_overrides);
 	} else
 		dealloc(arr); // none parsed, just free memory for the pre-allocated array.
 }

--- a/src/ckpool.c
+++ b/src/ckpool.c
@@ -1483,8 +1483,7 @@ static void parse_mindiff_overrides(ckpool_t *ckp, json_t *obj, const size_t n_k
 	if (n_ok) {
 		// Save info to ckp struct. Note we are being stingy with memory here and we realloc
 		// the array to the smaller size, just to be tidy.
-		const size_t nbytes = sizeof(mindiff_override_t) * n_ok;
-		ckp->mindiff_overrides = realloc(arr, nbytes);
+		ckp->mindiff_overrides = realloc(arr, sizeof(mindiff_override_t) * n_ok);
 		if (unlikely(!ckp->mindiff_overrides))
 			// realloc failure on startup.. this can't be good -- just re-use array.
 			ckp->mindiff_overrides = arr;

--- a/src/ckpool.c
+++ b/src/ckpool.c
@@ -1473,6 +1473,7 @@ static void parse_mindiff_overrides(ckpool_t *ckp, json_t *obj, const size_t n_k
 			mindiff = json_real_value(jval);
 		if (mindiff > 0 && useragent && *useragent) {
 			arr[n_ok].useragent = strdup(useragent);
+			arr[n_ok].ualen = strlen(arr[n_ok].useragent); // cache strlen to save cycles later
 			arr[n_ok].mindiff = mindiff;
 			++n_ok;
 		}  else {

--- a/src/ckpool.c
+++ b/src/ckpool.c
@@ -1474,7 +1474,6 @@ static void parse_mindiff_overrides(ckpool_t *ckp, json_t *obj, const size_t n_k
 		if (mindiff > 0 && useragent && *useragent) {
 			arr[n_ok].useragent = strdup(useragent);
 			arr[n_ok].mindiff = mindiff;
-			LOGDEBUG("mindiff_overrides: parsed \"%s\" mindiff %"PRId64, arr[n_ok].useragent, arr[n_ok].mindiff);
 			++n_ok;
 		}  else {
 			LOGWARNING("mindiff_overrides: failed to parse \"%s\", expected numeric value > 0", useragent ? : "");
@@ -1490,6 +1489,13 @@ static void parse_mindiff_overrides(ckpool_t *ckp, json_t *obj, const size_t n_k
 			// realloc failure on startup.. this can't be good -- just re-use array.
 			ckp->mindiff_overrides = arr;
 		ckp->n_mindiff_overrides = n_ok;
+		// debug sanity check, print out to log what we parsed
+		for (size_t i = 0; i < n_ok; ++i) {
+			LOGDEBUG("mindiff_overrides: parsed \"%s\" mindiff %"PRId64,
+			         ckp->mindiff_overrides[i].useragent,
+			         ckp->mindiff_overrides[i].mindiff);
+		}
+		LOGDEBUG("mindiff_overrides: %d overrides will be applied to clients on mining.subscribe", (int)ckp->n_mindiff_overrides);
 	} else
 		dealloc(arr); // none parsed, just free memory for the pre-allocated array.
 }

--- a/src/ckpool.c
+++ b/src/ckpool.c
@@ -1458,6 +1458,40 @@ out:
 	return ret;
 }
 
+static void parse_mindiff_overrides(ckpool_t *ckp, json_t *obj, const size_t n_keys)
+{
+	if (!n_keys || !obj || !ckp) return; // paranoia
+	mindiff_override_t *arr = ckzalloc(sizeof(mindiff_override_t) * n_keys);
+	size_t n_ok = 0;
+	for (void *it = json_object_iter(obj); it; it = json_object_iter_next(obj, it)) {
+		const char *useragent = json_object_iter_key(it);
+		const json_t *jval = json_object_iter_value(it);
+		int64_t mindiff = 0;
+		if (json_is_integer(jval))
+			mindiff = json_integer_value(jval);
+		else if (json_is_real(jval))
+			mindiff = json_real_value(jval);
+		if (mindiff > 0 && useragent && *useragent) {
+			arr[n_ok].useragent = strdup(useragent);
+			arr[n_ok].mindiff = mindiff;
+			LOGDEBUG("mindiff_overrides: parsed \"%s\" mindiff %"PRId64, arr[n_ok].useragent, arr[n_ok].mindiff);
+			++n_ok;
+		}  else {
+			LOGWARNING("mindiff_overrides: failed to parse \"%s\", expected numeric value > 0", useragent ? : "");
+		}
+		assert(n_ok <= n_keys);
+	}
+	if (n_ok) {
+		// Save info to ckp struct. Note we are being stingy with memory here and we realloc
+		// the array to the smaller size, just to be tidy.
+		const size_t nbytes = sizeof(mindiff_override_t) * n_ok;
+		if (unlikely(!(ckp->miniff_overrides = realloc(arr, nbytes))))
+			// realloc failure on startup.. this can't be good -- just re-use array.
+			ckp->mindiff_overrides = arr;
+		ckp->n_mindiff_overrides = n_ok;
+	} else
+		dealloc(arr); // none parsed, just free memory for the pre-allocated array.
+}
 
 static void parse_config(ckpool_t *ckp)
 {
@@ -1523,6 +1557,18 @@ static void parse_config(ckpool_t *ckp)
 	json_get_int64(&ckp->mindiff, json_conf, "mindiff");
 	json_get_int64(&ckp->startdiff, json_conf, "startdiff");
 	json_get_int64(&ckp->maxdiff, json_conf, "maxdiff");
+	{
+		json_t * obj = json_object_get(json_conf, "mindiff_overrides");
+		if (obj) {
+			size_t n_keys = 0;
+			if (!json_is_object(obj)) {
+				LOGWARNING("\"mindiff_overrides\" invalid, expected object, e.g. { ... } ");
+			} else if ((n_keys = json_object_size(obj))) {
+				parse_mindiff_overrides(ckp, obj, n_keys);
+			}
+		}
+	}
+
 	json_get_string(&ckp->logdir, json_conf, "logdir");
 	json_get_int(&ckp->maxclients, json_conf, "maxclients");
 	arr_val = json_object_get(json_conf, "proxy");

--- a/src/ckpool.c
+++ b/src/ckpool.c
@@ -1485,7 +1485,8 @@ static void parse_mindiff_overrides(ckpool_t *ckp, json_t *obj, const size_t n_k
 		// Save info to ckp struct. Note we are being stingy with memory here and we realloc
 		// the array to the smaller size, just to be tidy.
 		const size_t nbytes = sizeof(mindiff_override_t) * n_ok;
-		if (unlikely(!(ckp->miniff_overrides = realloc(arr, nbytes))))
+		ckp->mindiff_overrides = realloc(arr, nbytes);
+		if (unlikely(!ckp->mindiff_overrides))
 			// realloc failure on startup.. this can't be good -- just re-use array.
 			ckp->mindiff_overrides = arr;
 		ckp->n_mindiff_overrides = n_ok;

--- a/src/ckpool.h
+++ b/src/ckpool.h
@@ -130,12 +130,12 @@ struct server_instance {
 
 typedef struct server_instance server_instance_t;
 
-// Overrides for client mindiff and startdiff, applied based on useranget string from mining.subscribe.
+// Overrides for client mindiff and startdiff, applied based on useragent string from mining.subscribe.
 typedef struct mindiff_override {
 	/* If a client's useragent starts with this string (case insensitive),  then we apply the override. */
 	const char *useragent; // NB: in this program this is a malloc'd string owned by this object
 	size_t ualen; // strlen(useragent), cached so we don't have to recompute it each time
-	/* This override also affects client  startdiff iff > ckp->startdiff. */
+	/* This override is applied if it's >= global mindiff, it affects client starting difficulty and minimum difficulty. */
 	int64_t mindiff;
 } mindiff_override_t;
 

--- a/src/ckpool.h
+++ b/src/ckpool.h
@@ -134,6 +134,7 @@ typedef struct server_instance server_instance_t;
 typedef struct mindiff_override {
 	/* If a client's useragent starts with this string (case insensitive),  then we apply the override. */
 	const char *useragent; // NB: in this program this is a malloc'd string owned by this object
+	size_t ualen; // strlen(useragent), cached so we don't have to recompute it each time
 	/* This override also affects client  startdiff iff > ckp->startdiff. */
 	int64_t mindiff;
 } mindiff_override_t;

--- a/src/ckpool.h
+++ b/src/ckpool.h
@@ -130,6 +130,14 @@ struct server_instance {
 
 typedef struct server_instance server_instance_t;
 
+// Overrides for client mindiff and startdiff, applied based on useranget string from mining.subscribe.
+typedef struct mindiff_override {
+	/* If a client's useragent starts with this string (case insensitive),  then we apply the override. */
+	const char *useragent; // NB: in this program this is a malloc'd string owned by this object
+	/* This override also affects client  startdiff iff > ckp->startdiff. */
+	int64_t mindiff;
+} mindiff_override_t;
+
 struct ckpool_instance {
 	/* Start time */
 	time_t starttime;
@@ -242,6 +250,9 @@ struct ckpool_instance {
 	int64_t mindiff; // Default 1
 	int64_t startdiff; // Default 42
 	int64_t maxdiff; // No default
+
+	const mindiff_override_t *miniff_overrides; // Taken from top-level "mindiff_overrides" : { ... } in config.
+	size_t n_mindiff_overrides; // The number of mindiff_override in the above array. Will be 0 if array is NULL.
 
 	/* Which chain are we on: "main", "test", or "regtest". Defaults to "main" but may be read
 	   from bitcoind and updated if !proxy instance.

--- a/src/ckpool.h
+++ b/src/ckpool.h
@@ -251,7 +251,7 @@ struct ckpool_instance {
 	int64_t startdiff; // Default 42
 	int64_t maxdiff; // No default
 
-	const mindiff_override_t *miniff_overrides; // Taken from top-level "mindiff_overrides" : { ... } in config.
+	const mindiff_override_t *mindiff_overrides; // Taken from top-level "mindiff_overrides" : { ... } in config.
 	size_t n_mindiff_overrides; // The number of mindiff_override in the above array. Will be 0 if array is NULL.
 
 	/* Which chain are we on: "main", "test", or "regtest". Defaults to "main" but may be read

--- a/src/stratifier.c
+++ b/src/stratifier.c
@@ -5263,6 +5263,8 @@ static void __client_apply_mindiff_override(stratum_instance_t *client)
 		const mindiff_override_t * const ovr = ckp->mindiff_overrides + i;
 		if (ovr->mindiff <= ckp->mindiff)
 			continue; // ignore mindiff overrides below global minimum
+		if (ckp->maxdiff > 0 && ovr->mindiff > ckp->maxdiff)
+			continue; // ignore mindiff overrides above global maximum
 		if (0 == strncasecmp(client->useragent, ovr->useragent, ovr->ualen)) {
 			// match, apply suggested_diff to client, which will clamp
 			// the minimum difficulty for this client for all workers to be >= ovr->mindiff

--- a/src/stratifier.c
+++ b/src/stratifier.c
@@ -330,7 +330,7 @@ struct stratum_instance {
 	time_t last_txns; /* Last time this worker requested txn hashes */
 	time_t disconnected_time; /* Time this instance disconnected */
 
-	int64_t suggest_diff; /* Stratum client suggested diff */
+	int64_t suggest_diff; /* Stratum client suggested diff  - note this may also come from mindiff_overrides */
 	double best_diff; /* Best share found by this instance */
 
 	sdata_t *sdata; /* Which sdata this client is bound to */
@@ -5252,6 +5252,27 @@ out_unlock:
 	return ret;
 }
 
+static void __client_apply_mindiff_override(stratum_instance_t *client)
+{
+	ckpool_t *ckp = client->ckp;
+
+	if (!ckp->n_mindiff_overrides || !client->useragent || !*client->useragent)
+		return;
+	for (unsigned i = 0; i < ckp->n_mindiff_overrides; ++i) {
+		// linear search through known overrides based on useragent prefix
+		const mindiff_override_t * const ovr = ckp->mindiff_overrides + i;
+		if (ovr->mindiff <= ckp->mindiff)
+			continue; // ignore mindiff overrides below global minimum
+		if (0 == strncasecmp(client->useragent, ovr->useragent, ovr->ualen)) {
+			// match, apply suggested_diff to client, which will clamp
+			// the minimum difficulty for this client for all workers to be >= ovr->mindiff
+			client->suggest_diff = client->old_diff = client->diff = ovr->mindiff;
+			LOGDEBUG("Applied mindiff_override = %"PRId64" to client %"PRId64" matching \"%s\"", ovr->mindiff, client->id, ovr->useragent);
+			return;
+		}
+	}
+}
+
 /* Extranonce1 must be set here. Needs to be entered with client holding a ref
  * count. */
 static json_t *parse_subscribe(stratum_instance_t *client, const int64_t client_id, const json_t *params_val)
@@ -5359,6 +5380,8 @@ static json_t *parse_subscribe(stratum_instance_t *client, const int64_t client_
 	JSON_CPACK(ret, "[[[s,s]],s,i]", "mining.notify", sessionid, client->enonce1,
 			n2len);
 	ck_runlock(&sdata->workbase_lock);
+
+	__client_apply_mindiff_override(client); // set suggested_diff if any overrides defined for client based on useragent
 
 	client->subscribed = true;
 

--- a/src/stratifier.c
+++ b/src/stratifier.c
@@ -5381,7 +5381,13 @@ static json_t *parse_subscribe(stratum_instance_t *client, const int64_t client_
 			n2len);
 	ck_runlock(&sdata->workbase_lock);
 
-	__client_apply_mindiff_override(client); // set suggested_diff if any overrides defined for client based on useragent
+	// Apply any mindiff_overrides from config here.
+	// This sets client->suggest_diff, and initial client->diff, if any overrides match for this client
+	// (based on useragent).
+	// Known issue here: It's assumed the client sends mining.subscribe after initial connect.
+	// This call here won't spam a new difficulty change notification message, since the normal
+	// call path will send the initial difficulty message in init_client() later anyway. -Calin
+	__client_apply_mindiff_override(client);
 
 	client->subscribed = true;
 

--- a/src/stratifier.c
+++ b/src/stratifier.c
@@ -5267,7 +5267,7 @@ static void __client_apply_mindiff_override(stratum_instance_t *client)
 			// match, apply suggested_diff to client, which will clamp
 			// the minimum difficulty for this client for all workers to be >= ovr->mindiff
 			client->suggest_diff = client->old_diff = client->diff = ovr->mindiff;
-			LOGDEBUG("Applied mindiff_override = %"PRId64" to client %"PRId64" matching \"%s\"", ovr->mindiff, client->id, ovr->useragent);
+			LOGDEBUG("mindiff_overrides: Applied minimum difficulty = %"PRId64" to client %"PRId64" matching \"%s\"", ovr->mindiff, client->id, ovr->useragent);
 			return;
 		}
 	}


### PR DESCRIPTION
This implements the new `mindiff_overrides` config key.  The key is documented as follows:

---
```
"mindiff_overrides" : Optional JSON object (dictionary) of useragent, mindiff
pairs, e.g: `"mindiff_overrides" : { "nicehash" : 500000, "foohash" : 750000 }`
This is a mechanism to support a raised minimum difficulty for clients
connecting to the pool based on their "useragent" string (that they normally
send via `mining.subscribe` on initial connect).  The "useragent" specified
here is a prefix match (case insensitive).  If a client's useragent matches the
specified prefix, then it will have its minimum and starting difficulty set to
the override value.  Note: The override values specified here cannot be lower
than the pool's "mindiff" setting -- they must always be higher (similarly this
value must also be below "maxdiff").  This mechanism was initially designed so
that NiceHash clients can connect to a pool and get a special-cased raised
difficulty  (since NiceHash refuses to operate if share difficulty is < 500000
as of the time of this writing).
```

---

This feature re-uses the same machinery that was in place for the `mining.suggest_difficulty` stratum protocol method.  Basically, if a client's useragent string matches an override (prefix based match, case insensitive), then its minimum difficulty and starting difficulty will be set to the override, as if it had sent a `mining.suggest_difficulty` command to the server.

Note this has been tested by @tfaoro preliminarily, and appears to work as intended. The changes are minimally invasive, so it is safe to merge now.
